### PR TITLE
feat(idea): implement Idea CRUD API

### DIFF
--- a/idea_back/.claude/specs/issue-4-idea-crud/dev-plan.md
+++ b/idea_back/.claude/specs/issue-4-idea-crud/dev-plan.md
@@ -1,0 +1,131 @@
+# Idea CRUD API - Development Plan
+
+## Overview
+Implement complete Idea CRUD operations with JWT authentication, pagination, filtering, tag auto-creation, and soft delete support.
+
+## Task Breakdown
+
+### Task 1: Repository Layer Enhancement
+- **ID**: task-1
+- **type**: default
+- **Description**: Extend IdeaRepository with JpaSpecificationExecutor interface and create IdeaSpecifications utility class for dynamic query building. Add findByUserIdAndIdAndStatus method for ownership verification. Extend LikeRepository with findByUserIdAndIdeaIdIn batch query method.
+- **File Scope**:
+  - src/main/java/com/learn/demo/repository/IdeaRepository.java
+  - src/main/java/com/learn/demo/repository/LikeRepository.java
+  - src/main/java/com/learn/demo/specification/IdeaSpecifications.java (new)
+  - src/test/java/com/learn/demo/repository/IdeaRepositoryTest.java
+  - src/test/java/com/learn/demo/repository/LikeRepositoryTest.java
+  - src/test/java/com/learn/demo/specification/IdeaSpecificationsTest.java (new)
+- **Dependencies**: None
+- **Test Command**: `mvn test -Dtest=IdeaRepositoryTest,LikeRepositoryTest,IdeaSpecificationsTest -Djacoco.skip=false`
+- **Test Focus**:
+  - JpaSpecificationExecutor integration with IdeaRepository
+  - IdeaSpecifications: keyword search (title/description), tag filtering, userId filtering, status exclusion (DELETED)
+  - LikeRepository.findByUserIdAndIdeaIdIn: empty list, single idea, multiple ideas, non-existing ideas
+  - findByUserIdAndIdAndStatus: author access validation, non-author access denial
+
+### Task 2: DTO Layer
+- **ID**: task-2
+- **type**: default
+- **Description**: Create complete DTO suite for Idea CRUD operations including CreateIdeaRequest (title 1-100, description 1-5000, max 9 images), UpdateIdeaRequest (same validation), IdeaQueryRequest (page, size, sort, keyword, tag, userId), IdeaListResponse (with 200-char description snippet, author info, liked flag), IdeaDetailResponse (full description), and AuthorDto.
+- **File Scope**:
+  - src/main/java/com/learn/demo/dto/idea/CreateIdeaRequest.java (new)
+  - src/main/java/com/learn/demo/dto/idea/UpdateIdeaRequest.java (new)
+  - src/main/java/com/learn/demo/dto/idea/IdeaQueryRequest.java (new)
+  - src/main/java/com/learn/demo/dto/idea/IdeaListResponse.java (new)
+  - src/main/java/com/learn/demo/dto/idea/IdeaDetailResponse.java (new)
+  - src/main/java/com/learn/demo/dto/idea/AuthorDto.java (new)
+  - src/test/java/com/learn/demo/dto/idea/CreateIdeaRequestTest.java (new)
+  - src/test/java/com/learn/demo/dto/idea/UpdateIdeaRequestTest.java (new)
+  - src/test/java/com/learn/demo/dto/idea/IdeaQueryRequestTest.java (new)
+  - src/test/java/com/learn/demo/dto/idea/IdeaListResponseTest.java (new)
+  - src/test/java/com/learn/demo/dto/idea/IdeaDetailResponseTest.java (new)
+  - src/test/java/com/learn/demo/dto/idea/AuthorDtoTest.java (new)
+- **Dependencies**: None
+- **Test Command**: `mvn test -Dtest=CreateIdeaRequestTest,UpdateIdeaRequestTest,IdeaQueryRequestTest,IdeaListResponseTest,IdeaDetailResponseTest,AuthorDtoTest -Djacoco.skip=false`
+- **Test Focus**:
+  - CreateIdeaRequest validation: title length (0, 1, 100, 101), description length (0, 1, 5000, 5001), images count (0, 9, 10), null fields
+  - UpdateIdeaRequest: same validation rules as create
+  - IdeaQueryRequest: default values (page=0, size=20), size max limit (100), invalid sort fields, null keyword/tag handling
+  - IdeaListResponse: description substring logic (199, 200, 201 chars), null images/tags handling, author mapping, liked flag
+  - IdeaDetailResponse: full description preservation, null fields handling
+  - AuthorDto: null-safe field mapping
+
+### Task 3: Service Layer
+- **ID**: task-3
+- **type**: default
+- **Description**: Implement IdeaService with full CRUD logic including: paginated list query with dynamic filtering (keyword, tag, userId, status exclusion), detail retrieval, creation with tag auto-creation (findOrCreate + usageCount increment), update with tag sync (decrement old tags, increment new tags), soft delete (status=DELETED), and batch liked status query using LikeRepository.findByUserIdAndIdeaIdIn. Add permission checks (403 for non-author update/delete, admin bypass for delete).
+- **File Scope**:
+  - src/main/java/com/learn/demo/service/IdeaService.java (new)
+  - src/main/java/com/learn/demo/repository/TagRepository.java
+  - src/test/java/com/learn/demo/service/IdeaServiceTest.java (new)
+- **Dependencies**: depends on task-1, task-2
+- **Test Command**: `mvn test -Dtest=IdeaServiceTest -Djacoco.skip=false`
+- **Test Focus**:
+  - listIdeas: empty result, pagination (first/middle/last page), keyword filtering (title match, description match, case sensitivity), tag filtering (single/multiple tags), userId filtering, status exclusion (DELETED not returned), sort by createdAt/likeCount, liked flag batch query (no likes, partial likes, all liked)
+  - getIdeaDetail: existing idea, non-existing idea (404), DELETED idea (404), liked status
+  - createIdea: successful creation, new tag auto-creation with usageCount=1, existing tag reuse with usageCount++, max images validation
+  - updateIdea: author update success, non-author update (403), tag sync (old tags usageCount--, new tags usageCount++), non-existing idea (404)
+  - deleteIdea: author soft delete, admin soft delete, non-author non-admin (403), status set to DELETED, non-existing idea (404)
+  - getCurrentUserIdeas: pagination, only current user's ideas returned
+
+### Task 4: Controller Layer and Security Configuration
+- **ID**: task-4
+- **type**: default
+- **Description**: Implement IdeaController with endpoints: GET /api/ideas (paginated list with query params), GET /api/ideas/{id} (detail), POST /api/ideas (create), PUT /api/ideas/{id} (update), DELETE /api/ideas/{id} (soft delete), GET /api/users/me/ideas (current user's ideas). Update SecurityConfig to permit all authenticated users for idea endpoints and require admin role for delete operation (handled in service layer). All endpoints return ApiResponse or PageResponse wrappers.
+- **File Scope**:
+  - src/main/java/com/learn/demo/controller/IdeaController.java (new)
+  - src/main/java/com/learn/demo/config/SecurityConfig.java
+  - src/test/java/com/learn/demo/controller/IdeaControllerTest.java (new)
+- **Dependencies**: depends on task-3
+- **Test Command**: `mvn test -Dtest=IdeaControllerTest -Djacoco.skip=false`
+- **Test Focus**:
+  - GET /api/ideas: 200 with PageResponse, query param binding (page, size, sort, keyword, tag, userId), JWT authentication (401 without token)
+  - GET /api/ideas/{id}: 200 with ApiResponse, 404 for non-existing, 401 without JWT
+  - POST /api/ideas: 200 with created idea, 400 for validation errors (title/description length, max images), 401 without JWT
+  - PUT /api/ideas/{id}: 200 on success, 403 for non-author, 400 for validation errors, 404 for non-existing, 401 without JWT
+  - DELETE /api/ideas/{id}: 200 on success, 403 for non-author non-admin, 404 for non-existing, 401 without JWT
+  - GET /api/users/me/ideas: 200 with PageResponse, pagination params, 401 without JWT
+  - Response format consistency (ApiResponse/PageResponse structure)
+
+### Task 5: Integration Testing and Coverage Verification
+- **ID**: task-5
+- **type**: default
+- **Description**: Create comprehensive integration tests covering end-to-end workflows: user creates idea with tags, lists ideas with various filters, updates idea with tag changes, soft deletes idea, verifies idea not in list after deletion. Add edge case tests for concurrent tag creation, large dataset pagination, and permission boundary conditions. Verify overall code coverage meets 90% threshold.
+- **File Scope**:
+  - src/test/java/com/learn/demo/integration/IdeaCrudIntegrationTest.java (new)
+  - All source files in src/main/java/com/learn/demo/** related to Idea CRUD
+- **Dependencies**: depends on task-3, task-4
+- **Test Command**: `mvn clean test verify -Djacoco.skip=false`
+- **Test Focus**:
+  - End-to-end workflow: create → list (verify in results) → update → detail (verify changes) → delete → list (verify excluded)
+  - Tag lifecycle: new tag creation, existing tag reuse, tag count sync on update/delete
+  - Pagination edge cases: empty result, single page, multiple pages, last page partial results
+  - Permission enforcement: author-only update, admin delete bypass, non-owner 403
+  - Liked status accuracy: batch query correctness, user-specific liked flags
+  - Description snippet: 200-char truncation in list vs full text in detail
+  - Overall coverage report: verify ≥90% line coverage for all Idea CRUD modules
+
+## Acceptance Criteria
+- [ ] All 6 API endpoints implemented and functional (GET list, GET detail, POST create, PUT update, DELETE soft delete, GET user ideas)
+- [ ] Pagination works with configurable page, size (max 100), and sort (createdAt|likeCount)
+- [ ] Dynamic filtering by keyword (title/description), tag, userId, with DELETED status exclusion
+- [ ] Tag auto-creation and usageCount synchronization on create/update/delete
+- [ ] Description snippet (200 chars) in list response, full description in detail response
+- [ ] Liked flag batch querying using findByUserIdAndIdeaIdIn
+- [ ] Permission enforcement: author-only update, author/admin delete (403 for others)
+- [ ] JWT authentication required for all endpoints (401 without token)
+- [ ] All validation rules enforced (title 1-100, description 1-5000, max 9 images)
+- [ ] All unit tests pass
+- [ ] All integration tests pass
+- [ ] Code coverage ≥90%
+
+## Technical Notes
+- **JPA Specifications**: Use Specification API for dynamic query building to avoid repository method explosion
+- **Tag Management**: Implement findOrCreate pattern with optimistic locking to prevent duplicate tags during concurrent creation
+- **Batch Liked Query**: Collect all idea IDs from page result, query LikeRepository once with findByUserIdAndIdeaIdIn, map results to idea IDs to avoid N+1 queries
+- **Description Snippet**: Use database substring function in Specification for list query to reduce payload size, or implement in service layer if database function is not portable
+- **Soft Delete**: Never physically delete Idea records; set status=DELETED and exclude from all public queries
+- **Permission Check**: Implement in service layer, not controller, to ensure business logic encapsulation
+- **Test Data Isolation**: Use @Transactional with rollback in tests to prevent cross-test contamination
+- **Coverage Threshold**: Configured in pom.xml jacoco-maven-plugin with 90% line coverage minimum

--- a/idea_back/src/main/java/com/learn/demo/controller/IdeaController.java
+++ b/idea_back/src/main/java/com/learn/demo/controller/IdeaController.java
@@ -1,0 +1,83 @@
+package com.learn.demo.controller;
+
+import com.learn.demo.dto.ApiResponse;
+import com.learn.demo.dto.PageResponse;
+import com.learn.demo.dto.idea.CreateIdeaRequest;
+import com.learn.demo.dto.idea.IdeaDetailResponse;
+import com.learn.demo.dto.idea.IdeaListResponse;
+import com.learn.demo.dto.idea.IdeaQueryRequest;
+import com.learn.demo.dto.idea.UpdateIdeaRequest;
+import com.learn.demo.enums.UserRole;
+import com.learn.demo.security.UserPrincipal;
+import com.learn.demo.service.IdeaService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class IdeaController {
+    private final IdeaService ideaService;
+
+    @GetMapping("/ideas")
+    public ResponseEntity<ApiResponse<PageResponse<IdeaListResponse>>> listIdeas(
+            @ModelAttribute IdeaQueryRequest request,
+            @AuthenticationPrincipal UserPrincipal user) {
+        return ResponseEntity.ok(ApiResponse.success(
+            ideaService.listIdeas(request, user.getId())));
+    }
+
+    @GetMapping("/ideas/{id}")
+    public ResponseEntity<ApiResponse<IdeaDetailResponse>> getIdea(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal user) {
+        return ResponseEntity.ok(ApiResponse.success(
+            ideaService.getIdeaDetail(id, user.getId())));
+    }
+
+    @PostMapping("/ideas")
+    public ResponseEntity<ApiResponse<IdeaDetailResponse>> createIdea(
+            @Valid @RequestBody CreateIdeaRequest request,
+            @AuthenticationPrincipal UserPrincipal user) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(
+            ideaService.createIdea(request, user.getId())));
+    }
+
+    @PutMapping("/ideas/{id}")
+    public ResponseEntity<ApiResponse<IdeaDetailResponse>> updateIdea(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateIdeaRequest request,
+            @AuthenticationPrincipal UserPrincipal user) {
+        return ResponseEntity.ok(ApiResponse.success(
+            ideaService.updateIdea(id, request, user.getId())));
+    }
+
+    @DeleteMapping("/ideas/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteIdea(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal user) {
+        boolean isAdmin = user.getRole() == UserRole.ADMIN;
+        ideaService.deleteIdea(id, user.getId(), isAdmin);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @GetMapping("/users/me/ideas")
+    public ResponseEntity<ApiResponse<PageResponse<IdeaListResponse>>> getMyIdeas(
+            @ModelAttribute IdeaQueryRequest request,
+            @AuthenticationPrincipal UserPrincipal user) {
+        return ResponseEntity.ok(ApiResponse.success(
+            ideaService.getCurrentUserIdeas(request, user.getId())));
+    }
+}

--- a/idea_back/src/main/java/com/learn/demo/dto/idea/AuthorDto.java
+++ b/idea_back/src/main/java/com/learn/demo/dto/idea/AuthorDto.java
@@ -1,0 +1,28 @@
+package com.learn.demo.dto.idea;
+
+import com.learn.demo.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuthorDto {
+    private Long id;
+    private String username;
+    private String avatar;
+
+    public static AuthorDto fromUser(User user) {
+        if (user == null) {
+            return null;
+        }
+        return AuthorDto.builder()
+            .id(user.getId())
+            .username(user.getUsername())
+            .avatar(user.getAvatar())
+            .build();
+    }
+}

--- a/idea_back/src/main/java/com/learn/demo/dto/idea/CreateIdeaRequest.java
+++ b/idea_back/src/main/java/com/learn/demo/dto/idea/CreateIdeaRequest.java
@@ -1,0 +1,28 @@
+package com.learn.demo.dto.idea;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateIdeaRequest {
+    @NotBlank
+    @Size(min = 1, max = 100)
+    private String title;
+
+    @NotBlank
+    @Size(min = 1, max = 5000)
+    private String description;
+
+    @Size(max = 9)
+    private List<String> images;
+
+    private List<String> tags;
+}

--- a/idea_back/src/main/java/com/learn/demo/dto/idea/IdeaDetailResponse.java
+++ b/idea_back/src/main/java/com/learn/demo/dto/idea/IdeaDetailResponse.java
@@ -1,0 +1,57 @@
+package com.learn.demo.dto.idea;
+
+import com.learn.demo.entity.Idea;
+import com.learn.demo.entity.Tag;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IdeaDetailResponse {
+    private Long id;
+    private String title;
+    private String description;
+    private List<String> images;
+    private List<String> tags;
+    private AuthorDto author;
+    private Long likeCount;
+    private Long commentCount;
+    private boolean liked;
+    private LocalDateTime createdAt;
+
+    public static IdeaDetailResponse fromIdea(Idea idea, boolean liked) {
+        if (idea == null) {
+            return null;
+        }
+        List<String> images = idea.getImages() == null
+            ? Collections.emptyList()
+            : List.copyOf(idea.getImages());
+        List<String> tags = idea.getTags() == null
+            ? Collections.emptyList()
+            : idea.getTags().stream()
+                .map(Tag::getName)
+                .filter(Objects::nonNull)
+                .toList();
+
+        return IdeaDetailResponse.builder()
+            .id(idea.getId())
+            .title(idea.getTitle())
+            .description(idea.getDescription())
+            .images(images)
+            .tags(tags)
+            .author(AuthorDto.fromUser(idea.getUser()))
+            .likeCount(idea.getLikeCount())
+            .commentCount(idea.getCommentCount())
+            .liked(liked)
+            .createdAt(idea.getCreatedAt())
+            .build();
+    }
+}

--- a/idea_back/src/main/java/com/learn/demo/dto/idea/IdeaListResponse.java
+++ b/idea_back/src/main/java/com/learn/demo/dto/idea/IdeaListResponse.java
@@ -1,0 +1,60 @@
+package com.learn.demo.dto.idea;
+
+import com.learn.demo.entity.Idea;
+import com.learn.demo.entity.Tag;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IdeaListResponse {
+    private Long id;
+    private String title;
+    private String description;
+    private List<String> images;
+    private List<String> tags;
+    private AuthorDto author;
+    private Long likeCount;
+    private Long commentCount;
+    private boolean liked;
+    private LocalDateTime createdAt;
+
+    public static IdeaListResponse fromIdea(Idea idea, boolean liked) {
+        if (idea == null) {
+            return null;
+        }
+        List<String> images = idea.getImages() == null
+            ? Collections.emptyList()
+            : List.copyOf(idea.getImages());
+        List<String> tags = idea.getTags() == null
+            ? Collections.emptyList()
+            : idea.getTags().stream()
+                .map(Tag::getName)
+                .filter(Objects::nonNull)
+                .toList();
+        String description = idea.getDescription();
+        String snippet = description == null ? null
+            : description.length() <= 200 ? description : description.substring(0, 200);
+
+        return IdeaListResponse.builder()
+            .id(idea.getId())
+            .title(idea.getTitle())
+            .description(snippet)
+            .images(images)
+            .tags(tags)
+            .author(AuthorDto.fromUser(idea.getUser()))
+            .likeCount(idea.getLikeCount())
+            .commentCount(idea.getCommentCount())
+            .liked(liked)
+            .createdAt(idea.getCreatedAt())
+            .build();
+    }
+}

--- a/idea_back/src/main/java/com/learn/demo/dto/idea/IdeaQueryRequest.java
+++ b/idea_back/src/main/java/com/learn/demo/dto/idea/IdeaQueryRequest.java
@@ -1,0 +1,29 @@
+package com.learn.demo.dto.idea;
+
+import jakarta.validation.constraints.Max;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IdeaQueryRequest {
+    @Builder.Default
+    private int page = 0;
+
+    @Builder.Default
+    @Max(100)
+    private int size = 20;
+
+    @Builder.Default
+    private String sort = "createdAt,desc";
+
+    private String keyword;
+
+    private String tag;
+
+    private Long userId;
+}

--- a/idea_back/src/main/java/com/learn/demo/dto/idea/UpdateIdeaRequest.java
+++ b/idea_back/src/main/java/com/learn/demo/dto/idea/UpdateIdeaRequest.java
@@ -1,0 +1,28 @@
+package com.learn.demo.dto.idea;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateIdeaRequest {
+    @NotBlank
+    @Size(min = 1, max = 100)
+    private String title;
+
+    @NotBlank
+    @Size(min = 1, max = 5000)
+    private String description;
+
+    @Size(max = 9)
+    private List<String> images;
+
+    private List<String> tags;
+}

--- a/idea_back/src/main/java/com/learn/demo/repository/IdeaRepository.java
+++ b/idea_back/src/main/java/com/learn/demo/repository/IdeaRepository.java
@@ -2,16 +2,21 @@ package com.learn.demo.repository;
 
 import com.learn.demo.entity.Idea;
 import com.learn.demo.enums.IdeaStatus;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface IdeaRepository extends JpaRepository<Idea, Long> {
+public interface IdeaRepository
+	extends JpaRepository<Idea, Long>, JpaSpecificationExecutor<Idea> {
 	Page<Idea> findByUserId(Long userId, Pageable pageable);
 
 	Page<Idea> findByStatus(IdeaStatus status, Pageable pageable);
+
+	Optional<Idea> findByUserIdAndIdAndStatus(Long userId, Long id, IdeaStatus status);
 
 	@Query(
 		"select i from Idea i where i.title like %:keyword% or i.description like %:keyword%"

--- a/idea_back/src/main/java/com/learn/demo/repository/IdeaRepository.java
+++ b/idea_back/src/main/java/com/learn/demo/repository/IdeaRepository.java
@@ -5,10 +5,12 @@ import com.learn.demo.enums.IdeaStatus;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.domain.Specification;
 
 public interface IdeaRepository
 	extends JpaRepository<Idea, Long>, JpaSpecificationExecutor<Idea> {
@@ -22,4 +24,7 @@ public interface IdeaRepository
 		"select i from Idea i where i.title like %:keyword% or i.description like %:keyword%"
 	)
 	Page<Idea> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+	@EntityGraph(attributePaths = {"user", "tags"})
+	Page<Idea> findAll(Specification<Idea> spec, Pageable pageable);
 }

--- a/idea_back/src/main/java/com/learn/demo/repository/LikeRepository.java
+++ b/idea_back/src/main/java/com/learn/demo/repository/LikeRepository.java
@@ -1,6 +1,7 @@
 package com.learn.demo.repository;
 
 import com.learn.demo.entity.Like;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 	long countByIdeaId(Long ideaId);
 
 	Optional<Like> findByUserIdAndIdeaId(Long userId, Long ideaId);
+
+	List<Like> findByUserIdAndIdeaIdIn(Long userId, List<Long> ideaIds);
 }

--- a/idea_back/src/main/java/com/learn/demo/service/IdeaService.java
+++ b/idea_back/src/main/java/com/learn/demo/service/IdeaService.java
@@ -1,0 +1,258 @@
+package com.learn.demo.service;
+
+import com.learn.demo.dto.PageResponse;
+import com.learn.demo.dto.idea.CreateIdeaRequest;
+import com.learn.demo.dto.idea.IdeaDetailResponse;
+import com.learn.demo.dto.idea.IdeaListResponse;
+import com.learn.demo.dto.idea.IdeaQueryRequest;
+import com.learn.demo.dto.idea.UpdateIdeaRequest;
+import com.learn.demo.entity.Idea;
+import com.learn.demo.entity.Like;
+import com.learn.demo.entity.Tag;
+import com.learn.demo.entity.User;
+import com.learn.demo.enums.IdeaStatus;
+import com.learn.demo.exception.BusinessException;
+import com.learn.demo.repository.IdeaRepository;
+import com.learn.demo.repository.LikeRepository;
+import com.learn.demo.repository.TagRepository;
+import com.learn.demo.repository.UserRepository;
+import com.learn.demo.specification.IdeaSpecifications;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class IdeaService {
+    private static final String IDEA_NOT_FOUND = "Idea not found";
+    private static final String USER_NOT_FOUND = "User not found";
+    private static final String FORBIDDEN = "Forbidden";
+    private static final Set<String> ALLOWED_SORT_FIELDS = Set.of("createdAt", "likeCount");
+
+    private final IdeaRepository ideaRepository;
+    private final UserRepository userRepository;
+    private final TagRepository tagRepository;
+    private final LikeRepository likeRepository;
+
+    public PageResponse<IdeaListResponse> listIdeas(IdeaQueryRequest request, Long currentUserId) {
+        Specification<Idea> spec = IdeaSpecifications.combine(request);
+        Pageable pageable = buildPageable(request);
+        Page<Idea> page = ideaRepository.findAll(spec, pageable);
+
+        List<Idea> ideas = page.getContent();
+        List<Long> ideaIds = ideas.stream()
+            .map(Idea::getId)
+            .filter(Objects::nonNull)
+            .toList();
+
+        Set<Long> likedIdeaIds = resolveLikedIdeaIds(currentUserId, ideaIds);
+        List<IdeaListResponse> content = ideas.stream()
+            .map(idea -> IdeaListResponse.fromIdea(idea, likedIdeaIds.contains(idea.getId())))
+            .toList();
+
+        Page<IdeaListResponse> responsePage = new PageImpl<>(content, pageable, page.getTotalElements());
+        return PageResponse.of(responsePage);
+    }
+
+    public IdeaDetailResponse getIdeaDetail(Long id, Long currentUserId) {
+        Idea idea = ideaRepository.findById(id)
+            .orElseThrow(() -> new BusinessException(404, IDEA_NOT_FOUND));
+        if (idea.getStatus() == IdeaStatus.DELETED) {
+            throw new BusinessException(404, IDEA_NOT_FOUND);
+        }
+
+        boolean liked = currentUserId != null && likeRepository.existsByUserIdAndIdeaId(currentUserId, id);
+        return IdeaDetailResponse.fromIdea(idea, liked);
+    }
+
+    @Transactional
+    public IdeaDetailResponse createIdea(CreateIdeaRequest request, Long currentUserId) {
+        User user = userRepository.findById(currentUserId)
+            .orElseThrow(() -> new BusinessException(404, USER_NOT_FOUND));
+
+        Idea idea = new Idea();
+        idea.setUser(user);
+        idea.setTitle(request.getTitle());
+        idea.setDescription(request.getDescription());
+        idea.setImages(request.getImages());
+        idea.setStatus(IdeaStatus.ACTIVE);
+        idea.setTags(syncTags(Collections.emptySet(), request.getTags()));
+
+        Idea saved = ideaRepository.save(idea);
+        return IdeaDetailResponse.fromIdea(saved, false);
+    }
+
+    @Transactional
+    public IdeaDetailResponse updateIdea(Long id, UpdateIdeaRequest request, Long currentUserId) {
+        Idea idea = ideaRepository.findById(id)
+            .orElseThrow(() -> new BusinessException(404, IDEA_NOT_FOUND));
+        if (idea.getStatus() == IdeaStatus.DELETED) {
+            throw new BusinessException(404, IDEA_NOT_FOUND);
+        }
+        if (!Objects.equals(idea.getUser().getId(), currentUserId)) {
+            throw new BusinessException(403, FORBIDDEN);
+        }
+
+        idea.setTitle(request.getTitle());
+        idea.setDescription(request.getDescription());
+        idea.setImages(request.getImages());
+        idea.setTags(syncTags(idea.getTags(), request.getTags()));
+
+        Idea saved = ideaRepository.save(idea);
+        boolean liked = currentUserId != null && likeRepository.existsByUserIdAndIdeaId(currentUserId, id);
+        return IdeaDetailResponse.fromIdea(saved, liked);
+    }
+
+    @Transactional
+    public void deleteIdea(Long id, Long currentUserId, boolean isAdmin) {
+        Idea idea = ideaRepository.findById(id)
+            .orElseThrow(() -> new BusinessException(404, IDEA_NOT_FOUND));
+        if (idea.getStatus() == IdeaStatus.DELETED) {
+            throw new BusinessException(404, IDEA_NOT_FOUND);
+        }
+        if (!isAdmin && !Objects.equals(idea.getUser().getId(), currentUserId)) {
+            throw new BusinessException(403, FORBIDDEN);
+        }
+
+        for (Tag tag : safeTagSet(idea.getTags())) {
+            decrementUsage(tag);
+            tagRepository.save(tag);
+        }
+        idea.setStatus(IdeaStatus.DELETED);
+        ideaRepository.save(idea);
+    }
+
+    public PageResponse<IdeaListResponse> getCurrentUserIdeas(IdeaQueryRequest request, Long currentUserId) {
+        request.setUserId(currentUserId);
+        return listIdeas(request, currentUserId);
+    }
+
+    private Pageable buildPageable(IdeaQueryRequest request) {
+        String sortValue = request.getSort();
+        String sortField = "createdAt";
+        Sort.Direction direction = Sort.Direction.DESC;
+
+        if (sortValue != null && !sortValue.isBlank()) {
+            String[] parts = sortValue.split(",");
+            if (parts.length > 0 && !parts[0].isBlank()) {
+                String candidate = parts[0].trim();
+                if (ALLOWED_SORT_FIELDS.contains(candidate)) {
+                    sortField = candidate;
+                }
+            }
+            if (parts.length > 1 && !parts[1].isBlank()) {
+                direction = "asc".equalsIgnoreCase(parts[1].trim())
+                    ? Sort.Direction.ASC
+                    : Sort.Direction.DESC;
+            }
+        }
+
+        return PageRequest.of(request.getPage(), request.getSize(), Sort.by(direction, sortField));
+    }
+
+    private Set<Long> resolveLikedIdeaIds(Long currentUserId, List<Long> ideaIds) {
+        if (currentUserId == null || ideaIds.isEmpty()) {
+            return Collections.emptySet();
+        }
+        List<Like> likes = likeRepository.findByUserIdAndIdeaIdIn(currentUserId, ideaIds);
+        return likes.stream()
+            .map(like -> like.getIdea() == null ? null : like.getIdea().getId())
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    }
+
+    private Set<Tag> syncTags(Set<Tag> currentTags, List<String> requestedTags) {
+        Set<Tag> safeCurrent = safeTagSet(currentTags);
+        Map<String, Tag> currentByLower = new HashMap<>();
+        for (Tag tag : safeCurrent) {
+            if (tag.getName() != null) {
+                currentByLower.put(tag.getName().toLowerCase(), tag);
+            }
+        }
+
+        List<String> normalized = normalizeTagNames(requestedTags);
+        Set<String> normalizedLower = normalized.stream()
+            .map(name -> name.toLowerCase())
+            .collect(Collectors.toSet());
+
+        for (Tag tag : safeCurrent) {
+            String name = tag.getName();
+            if (name != null && !normalizedLower.contains(name.toLowerCase())) {
+                decrementUsage(tag);
+                tagRepository.save(tag);
+            }
+        }
+
+        Set<Tag> result = new HashSet<>();
+        for (String name : normalized) {
+            String lower = name.toLowerCase();
+            Tag existing = currentByLower.get(lower);
+            if (existing != null) {
+                result.add(existing);
+                continue;
+            }
+            Tag tag = tagRepository.findByNameIgnoreCase(name).orElseGet(() -> {
+                Tag created = new Tag();
+                created.setName(name);
+                created.setUsageCount(0L);
+                return created;
+            });
+            incrementUsage(tag);
+            tagRepository.save(tag);
+            result.add(tag);
+        }
+
+        return result;
+    }
+
+    private List<String> normalizeTagNames(List<String> names) {
+        if (names == null || names.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Map<String, String> normalized = new LinkedHashMap<>();
+        for (String name : names) {
+            if (name == null) {
+                continue;
+            }
+            String trimmed = name.trim();
+            if (trimmed.isBlank()) {
+                continue;
+            }
+            normalized.putIfAbsent(trimmed.toLowerCase(), trimmed);
+        }
+        return new ArrayList<>(normalized.values());
+    }
+
+    private Set<Tag> safeTagSet(Set<Tag> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return new HashSet<>(tags);
+    }
+
+    private void incrementUsage(Tag tag) {
+        long count = tag.getUsageCount() == null ? 0L : tag.getUsageCount();
+        tag.setUsageCount(count + 1L);
+    }
+
+    private void decrementUsage(Tag tag) {
+        long count = tag.getUsageCount() == null ? 0L : tag.getUsageCount();
+        tag.setUsageCount(Math.max(0L, count - 1L));
+    }
+}

--- a/idea_back/src/main/java/com/learn/demo/specification/IdeaSpecifications.java
+++ b/idea_back/src/main/java/com/learn/demo/specification/IdeaSpecifications.java
@@ -20,6 +20,7 @@ public class IdeaSpecifications {
     public static Specification<Idea> withTag(String tagName) {
         if (tagName == null || tagName.isBlank()) return null;
         return (root, query, cb) -> {
+            query.distinct(true);
             Join<Idea, Tag> tags = root.join("tags");
             return cb.equal(cb.lower(tags.get("name")), tagName.toLowerCase());
         };

--- a/idea_back/src/main/java/com/learn/demo/specification/IdeaSpecifications.java
+++ b/idea_back/src/main/java/com/learn/demo/specification/IdeaSpecifications.java
@@ -1,0 +1,53 @@
+package com.learn.demo.specification;
+
+import com.learn.demo.dto.idea.IdeaQueryRequest;
+import com.learn.demo.entity.Idea;
+import com.learn.demo.entity.Tag;
+import com.learn.demo.enums.IdeaStatus;
+import jakarta.persistence.criteria.Join;
+import org.springframework.data.jpa.domain.Specification;
+
+public class IdeaSpecifications {
+    public static Specification<Idea> withKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) return null;
+        String pattern = "%" + keyword.toLowerCase() + "%";
+        return (root, query, cb) -> cb.or(
+            cb.like(cb.lower(root.get("title")), pattern),
+            cb.like(cb.lower(root.get("description")), pattern)
+        );
+    }
+
+    public static Specification<Idea> withTag(String tagName) {
+        if (tagName == null || tagName.isBlank()) return null;
+        return (root, query, cb) -> {
+            Join<Idea, Tag> tags = root.join("tags");
+            return cb.equal(cb.lower(tags.get("name")), tagName.toLowerCase());
+        };
+    }
+
+    public static Specification<Idea> withUserId(Long userId) {
+        if (userId == null) return null;
+        return (root, query, cb) -> cb.equal(root.get("user").get("id"), userId);
+    }
+
+    public static Specification<Idea> excludeDeleted() {
+        return (root, query, cb) -> cb.notEqual(root.get("status"), IdeaStatus.DELETED);
+    }
+
+    public static Specification<Idea> combine(IdeaQueryRequest request) {
+        Specification<Idea> spec = Specification.where(excludeDeleted());
+        Specification<Idea> keywordSpec = withKeyword(request.getKeyword());
+        if (keywordSpec != null) {
+            spec = spec.and(keywordSpec);
+        }
+        Specification<Idea> tagSpec = withTag(request.getTag());
+        if (tagSpec != null) {
+            spec = spec.and(tagSpec);
+        }
+        Specification<Idea> userSpec = withUserId(request.getUserId());
+        if (userSpec != null) {
+            spec = spec.and(userSpec);
+        }
+        return spec;
+    }
+}

--- a/idea_back/src/test/java/com/learn/demo/controller/IdeaControllerTest.java
+++ b/idea_back/src/test/java/com/learn/demo/controller/IdeaControllerTest.java
@@ -1,0 +1,390 @@
+package com.learn.demo.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.learn.demo.dto.PageResponse;
+import com.learn.demo.dto.idea.CreateIdeaRequest;
+import com.learn.demo.dto.idea.IdeaDetailResponse;
+import com.learn.demo.dto.idea.IdeaListResponse;
+import com.learn.demo.dto.idea.IdeaQueryRequest;
+import com.learn.demo.dto.idea.UpdateIdeaRequest;
+import com.learn.demo.entity.User;
+import com.learn.demo.enums.UserRole;
+import com.learn.demo.enums.UserStatus;
+import com.learn.demo.exception.BusinessException;
+import com.learn.demo.security.JwtTokenProvider;
+import com.learn.demo.security.UserPrincipal;
+import com.learn.demo.service.IdeaService;
+import com.learn.demo.service.CustomUserDetailsService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.jpa.properties.hibernate.globally_quoted_identifiers=true",
+    "jwt.secret=testSecretKeyForUnitTestingPurposesOnly12345678901234567890",
+    "jwt.expiration=86400000"
+})
+class IdeaControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private IdeaService ideaService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Test
+    void listIdeasReturns200AndBindsParams() throws Exception {
+        PageResponse<IdeaListResponse> response = PageResponse.<IdeaListResponse>builder()
+            .content(List.of(IdeaListResponse.builder()
+                .id(1L)
+                .title("t")
+                .description("d")
+                .liked(true)
+                .createdAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                .build()))
+            .page(1)
+            .size(10)
+            .totalElements(1)
+            .totalPages(1)
+            .build();
+        when(ideaService.listIdeas(any(IdeaQueryRequest.class), eq(7L))).thenReturn(response);
+
+        mockMvc.perform(get("/api/ideas")
+                .param("page", "1")
+                .param("size", "10")
+                .param("sort", "likeCount,asc")
+                .param("keyword", "search")
+                .param("tag", "java")
+                .param("userId", "99")
+                .with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.data.content[0].id").value(1));
+
+        ArgumentCaptor<IdeaQueryRequest> captor = ArgumentCaptor.forClass(IdeaQueryRequest.class);
+        verify(ideaService).listIdeas(captor.capture(), eq(7L));
+        IdeaQueryRequest captured = captor.getValue();
+        org.junit.jupiter.api.Assertions.assertEquals(1, captured.getPage());
+        org.junit.jupiter.api.Assertions.assertEquals(10, captured.getSize());
+        org.junit.jupiter.api.Assertions.assertEquals("likeCount,asc", captured.getSort());
+        org.junit.jupiter.api.Assertions.assertEquals("search", captured.getKeyword());
+        org.junit.jupiter.api.Assertions.assertEquals("java", captured.getTag());
+        org.junit.jupiter.api.Assertions.assertEquals(99L, captured.getUserId());
+    }
+
+    @Test
+    void listIdeasUnauthorizedReturns401() throws Exception {
+        mockMvc.perform(get("/api/ideas"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getIdeaReturns200() throws Exception {
+        IdeaDetailResponse response = IdeaDetailResponse.builder()
+            .id(2L)
+            .title("idea")
+            .description("detail")
+            .liked(false)
+            .createdAt(LocalDateTime.of(2024, 1, 2, 0, 0))
+            .build();
+        when(ideaService.getIdeaDetail(2L, 7L)).thenReturn(response);
+
+        mockMvc.perform(get("/api/ideas/2").with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.data.id").value(2));
+    }
+
+    @Test
+    void getIdeaNotFoundReturns404() throws Exception {
+        when(ideaService.getIdeaDetail(9L, 7L))
+            .thenThrow(new BusinessException(404, "Idea not found"));
+
+        mockMvc.perform(get("/api/ideas/9").with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("Idea not found"));
+    }
+
+    @Test
+    void getIdeaUnauthorizedReturns401() throws Exception {
+        mockMvc.perform(get("/api/ideas/2"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void createIdeaReturns201() throws Exception {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title("title")
+            .description("desc")
+            .images(List.of("img"))
+            .tags(List.of("tag"))
+            .build();
+        IdeaDetailResponse response = IdeaDetailResponse.builder()
+            .id(3L)
+            .title("title")
+            .description("desc")
+            .liked(false)
+            .build();
+        when(ideaService.createIdea(any(CreateIdeaRequest.class), eq(7L))).thenReturn(response);
+
+        mockMvc.perform(post("/api/ideas")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.data.id").value(3));
+    }
+
+    @Test
+    void createIdeaValidationReturns400() throws Exception {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title("")
+            .description("")
+            .build();
+
+        mockMvc.perform(post("/api/ideas")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Validation failed"));
+    }
+
+    @Test
+    void createIdeaUnauthorizedReturns401() throws Exception {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title("title")
+            .description("desc")
+            .build();
+
+        mockMvc.perform(post("/api/ideas")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void updateIdeaReturns200() throws Exception {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("t")
+            .description("d")
+            .build();
+        IdeaDetailResponse response = IdeaDetailResponse.builder()
+            .id(4L)
+            .title("t")
+            .description("d")
+            .liked(true)
+            .build();
+        when(ideaService.updateIdea(eq(4L), any(UpdateIdeaRequest.class), eq(7L))).thenReturn(response);
+
+        mockMvc.perform(put("/api/ideas/4")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.data.id").value(4));
+    }
+
+    @Test
+    void updateIdeaValidationReturns400() throws Exception {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("")
+            .description("")
+            .build();
+
+        mockMvc.perform(put("/api/ideas/4")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Validation failed"));
+    }
+
+    @Test
+    void updateIdeaForbiddenReturns403() throws Exception {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("t")
+            .description("d")
+            .build();
+        when(ideaService.updateIdea(eq(4L), any(UpdateIdeaRequest.class), eq(7L)))
+            .thenThrow(new BusinessException(403, "Forbidden"));
+
+        mockMvc.perform(put("/api/ideas/4")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value(403))
+            .andExpect(jsonPath("$.message").value("Forbidden"));
+    }
+
+    @Test
+    void updateIdeaNotFoundReturns404() throws Exception {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("t")
+            .description("d")
+            .build();
+        when(ideaService.updateIdea(eq(5L), any(UpdateIdeaRequest.class), eq(7L)))
+            .thenThrow(new BusinessException(404, "Idea not found"));
+
+        mockMvc.perform(put("/api/ideas/5")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("Idea not found"));
+    }
+
+    @Test
+    void updateIdeaUnauthorizedReturns401() throws Exception {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("t")
+            .description("d")
+            .build();
+
+        mockMvc.perform(put("/api/ideas/5")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deleteIdeaReturns200ForAdmin() throws Exception {
+        doNothing().when(ideaService).deleteIdea(6L, 8L, true);
+
+        mockMvc.perform(delete("/api/ideas/6").with(auth(UserRole.ADMIN, 8L)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(200));
+
+        verify(ideaService).deleteIdea(6L, 8L, true);
+    }
+
+    @Test
+    void deleteIdeaForbiddenReturns403() throws Exception {
+        doThrow(new BusinessException(403, "Forbidden"))
+            .when(ideaService).deleteIdea(6L, 7L, false);
+
+        mockMvc.perform(delete("/api/ideas/6").with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value(403))
+            .andExpect(jsonPath("$.message").value("Forbidden"));
+
+        verify(ideaService).deleteIdea(6L, 7L, false);
+    }
+
+    @Test
+    void deleteIdeaNotFoundReturns404() throws Exception {
+        doThrow(new BusinessException(404, "Idea not found"))
+            .when(ideaService).deleteIdea(10L, 7L, false);
+
+        mockMvc.perform(delete("/api/ideas/10").with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("Idea not found"));
+    }
+
+    @Test
+    void deleteIdeaUnauthorizedReturns401() throws Exception {
+        mockMvc.perform(delete("/api/ideas/6"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getMyIdeasReturns200AndBindsParams() throws Exception {
+        PageResponse<IdeaListResponse> response = PageResponse.<IdeaListResponse>builder()
+            .content(List.of())
+            .page(0)
+            .size(5)
+            .totalElements(0)
+            .totalPages(0)
+            .build();
+        when(ideaService.getCurrentUserIdeas(any(IdeaQueryRequest.class), eq(7L))).thenReturn(response);
+
+        mockMvc.perform(get("/api/users/me/ideas")
+                .param("page", "0")
+                .param("size", "5")
+                .param("sort", "createdAt,desc")
+                .param("keyword", "x")
+                .param("tag", "y")
+                .with(auth(UserRole.USER, 7L)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(200));
+
+        ArgumentCaptor<IdeaQueryRequest> captor = ArgumentCaptor.forClass(IdeaQueryRequest.class);
+        verify(ideaService).getCurrentUserIdeas(captor.capture(), eq(7L));
+        IdeaQueryRequest captured = captor.getValue();
+        org.junit.jupiter.api.Assertions.assertEquals(0, captured.getPage());
+        org.junit.jupiter.api.Assertions.assertEquals(5, captured.getSize());
+        org.junit.jupiter.api.Assertions.assertEquals("createdAt,desc", captured.getSort());
+        org.junit.jupiter.api.Assertions.assertEquals("x", captured.getKeyword());
+        org.junit.jupiter.api.Assertions.assertEquals("y", captured.getTag());
+    }
+
+    @Test
+    void getMyIdeasUnauthorizedReturns401() throws Exception {
+        mockMvc.perform(get("/api/users/me/ideas"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    private RequestPostProcessor auth(UserRole role, Long userId) {
+        User user = new User();
+        user.setId(userId);
+        user.setUsername("user" + userId);
+        user.setPassword("pass");
+        user.setRole(role);
+        user.setStatus(UserStatus.ACTIVE);
+        UserPrincipal principal = new UserPrincipal(user);
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+            principal,
+            null,
+            principal.getAuthorities()
+        );
+        return authentication(authentication);
+    }
+}

--- a/idea_back/src/test/java/com/learn/demo/controller/UserControllerTest.java
+++ b/idea_back/src/test/java/com/learn/demo/controller/UserControllerTest.java
@@ -18,8 +18,10 @@ import com.learn.demo.security.UserPrincipal;
 import com.learn.demo.security.JwtTokenProvider;
 import com.learn.demo.service.CustomUserDetailsService;
 import com.learn.demo.service.UserService;
+import com.learn.demo.config.FileStorageConfig;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -55,6 +57,7 @@ class UserControllerTest {
 
     @MockitoBean
     private CustomUserDetailsService customUserDetailsService;
+
 
     @Test
     @WithMockUser(username = "alice")
@@ -150,6 +153,13 @@ class UserControllerTest {
     }
 
     static class TestConfig implements WebMvcConfigurer {
+        @org.springframework.context.annotation.Bean
+        public FileStorageConfig fileStorageConfig() {
+            FileStorageConfig config = new FileStorageConfig();
+            config.setUploadDir("./uploads");
+            return config;
+        }
+
         @Override
         public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
             resolvers.add(new HandlerMethodArgumentResolver() {

--- a/idea_back/src/test/java/com/learn/demo/dto/idea/AuthorDtoTest.java
+++ b/idea_back/src/test/java/com/learn/demo/dto/idea/AuthorDtoTest.java
@@ -1,0 +1,28 @@
+package com.learn.demo.dto.idea;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.learn.demo.entity.User;
+import org.junit.jupiter.api.Test;
+
+class AuthorDtoTest {
+
+    @Test
+    void fromUserMapsFields() {
+        User user = new User();
+        user.setId(5L);
+        user.setUsername("alice");
+        user.setAvatar("avatar.png");
+
+        AuthorDto dto = AuthorDto.fromUser(user);
+        assertEquals(5L, dto.getId());
+        assertEquals("alice", dto.getUsername());
+        assertEquals("avatar.png", dto.getAvatar());
+    }
+
+    @Test
+    void fromUserReturnsNullWhenUserNull() {
+        assertNull(AuthorDto.fromUser(null));
+    }
+}

--- a/idea_back/src/test/java/com/learn/demo/dto/idea/CreateIdeaRequestTest.java
+++ b/idea_back/src/test/java/com/learn/demo/dto/idea/CreateIdeaRequestTest.java
@@ -1,0 +1,130 @@
+package com.learn.demo.dto.idea;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class CreateIdeaRequestTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void validRequestPassesValidation() {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title("a")
+            .description("b")
+            .images(List.of())
+            .tags(List.of("tag"))
+            .build();
+
+        Set<ConstraintViolation<CreateIdeaRequest>> violations = validator.validate(request);
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    void blankTitleFailsValidation() {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title(" ")
+            .description("desc")
+            .build();
+
+        Set<ConstraintViolation<CreateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("title", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void titleTooLongFailsValidation() {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title(repeat("a", 101))
+            .description("desc")
+            .build();
+
+        Set<ConstraintViolation<CreateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("title", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void descriptionTooLongFailsValidation() {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title("title")
+            .description(repeat("a", 5001))
+            .build();
+
+        Set<ConstraintViolation<CreateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("description", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void tooManyImagesFailsValidation() {
+        List<String> images = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            images.add("img" + i);
+        }
+
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title("title")
+            .description("desc")
+            .images(images)
+            .build();
+
+        Set<ConstraintViolation<CreateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("images", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void nullTitleFailsValidation() {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title(null)
+            .description("desc")
+            .build();
+
+        Set<ConstraintViolation<CreateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("title", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void nullDescriptionFailsValidation() {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title("title")
+            .description(null)
+            .build();
+
+        Set<ConstraintViolation<CreateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("description", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void boundaryLengthsPassValidation() {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title(repeat("a", 100))
+            .description(repeat("b", 5000))
+            .images(List.of("1", "2", "3", "4", "5", "6", "7", "8", "9"))
+            .build();
+
+        Set<ConstraintViolation<CreateIdeaRequest>> violations = validator.validate(request);
+        assertTrue(violations.isEmpty());
+    }
+
+    private static String repeat(String value, int count) {
+        return value.repeat(count);
+    }
+}

--- a/idea_back/src/test/java/com/learn/demo/dto/idea/IdeaDetailResponseTest.java
+++ b/idea_back/src/test/java/com/learn/demo/dto/idea/IdeaDetailResponseTest.java
@@ -1,0 +1,82 @@
+package com.learn.demo.dto.idea;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.learn.demo.entity.Idea;
+import com.learn.demo.entity.Tag;
+import com.learn.demo.entity.User;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class IdeaDetailResponseTest {
+
+    @Test
+    void descriptionPreservesFullText() {
+        String description = repeat("a", 300);
+        Idea idea = buildIdea(description);
+
+        IdeaDetailResponse response = IdeaDetailResponse.fromIdea(idea, false);
+        assertEquals(300, response.getDescription().length());
+    }
+
+    @Test
+    void nullImagesAndTagsReturnEmptyLists() {
+        Idea idea = buildIdea("desc");
+        idea.setImages(null);
+        idea.setTags(null);
+
+        IdeaDetailResponse response = IdeaDetailResponse.fromIdea(idea, false);
+        assertNotNull(response.getImages());
+        assertNotNull(response.getTags());
+        assertTrue(response.getImages().isEmpty());
+        assertTrue(response.getTags().isEmpty());
+    }
+
+    @Test
+    void authorAndCountsMappedCorrectly() {
+        Idea idea = buildIdea("desc");
+        idea.setLikeCount(7L);
+        idea.setCommentCount(2L);
+
+        IdeaDetailResponse response = IdeaDetailResponse.fromIdea(idea, true);
+        assertEquals(7L, response.getLikeCount());
+        assertEquals(2L, response.getCommentCount());
+        assertEquals(1L, response.getAuthor().getId());
+        assertEquals("user1", response.getAuthor().getUsername());
+        assertEquals("avatar.png", response.getAuthor().getAvatar());
+        assertTrue(response.isLiked());
+    }
+
+    private static Idea buildIdea(String description) {
+        Idea idea = new Idea();
+        idea.setId(1L);
+        idea.setTitle("title");
+        idea.setDescription(description);
+        idea.setImages(List.of("img1"));
+        idea.setCreatedAt(LocalDateTime.of(2024, 1, 1, 0, 0));
+        idea.setLikeCount(0L);
+        idea.setCommentCount(0L);
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("user1");
+        user.setAvatar("avatar.png");
+        idea.setUser(user);
+
+        Tag tag1 = new Tag();
+        tag1.setName("tag1");
+        Set<Tag> tags = new HashSet<>();
+        tags.add(tag1);
+        idea.setTags(tags);
+        return idea;
+    }
+
+    private static String repeat(String value, int count) {
+        return value.repeat(count);
+    }
+}

--- a/idea_back/src/test/java/com/learn/demo/dto/idea/IdeaListResponseTest.java
+++ b/idea_back/src/test/java/com/learn/demo/dto/idea/IdeaListResponseTest.java
@@ -1,0 +1,99 @@
+package com.learn.demo.dto.idea;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.learn.demo.entity.Idea;
+import com.learn.demo.entity.Tag;
+import com.learn.demo.entity.User;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class IdeaListResponseTest {
+
+    @Test
+    void descriptionSnippetUsesFullTextWhenShorterThanLimit() {
+        Idea idea = buildIdea(repeat("a", 199));
+        IdeaListResponse response = IdeaListResponse.fromIdea(idea, false);
+        assertEquals(199, response.getDescription().length());
+    }
+
+    @Test
+    void descriptionSnippetUsesFullTextWhenAtLimit() {
+        Idea idea = buildIdea(repeat("a", 200));
+        IdeaListResponse response = IdeaListResponse.fromIdea(idea, false);
+        assertEquals(200, response.getDescription().length());
+    }
+
+    @Test
+    void descriptionSnippetTruncatesWhenOverLimit() {
+        Idea idea = buildIdea(repeat("a", 201));
+        IdeaListResponse response = IdeaListResponse.fromIdea(idea, true);
+        assertEquals(200, response.getDescription().length());
+        assertTrue(response.isLiked());
+    }
+
+    @Test
+    void nullImagesAndTagsReturnEmptyLists() {
+        Idea idea = buildIdea("desc");
+        idea.setImages(null);
+        idea.setTags(null);
+
+        IdeaListResponse response = IdeaListResponse.fromIdea(idea, false);
+        assertNotNull(response.getImages());
+        assertNotNull(response.getTags());
+        assertTrue(response.getImages().isEmpty());
+        assertTrue(response.getTags().isEmpty());
+    }
+
+    @Test
+    void authorAndCountsMappedCorrectly() {
+        Idea idea = buildIdea("desc");
+        idea.setLikeCount(12L);
+        idea.setCommentCount(3L);
+
+        IdeaListResponse response = IdeaListResponse.fromIdea(idea, false);
+        assertEquals(12L, response.getLikeCount());
+        assertEquals(3L, response.getCommentCount());
+        assertEquals(1L, response.getAuthor().getId());
+        assertEquals("user1", response.getAuthor().getUsername());
+        assertEquals("avatar.png", response.getAuthor().getAvatar());
+        assertTrue(response.getTags().containsAll(List.of("tag1", "tag2")));
+        assertEquals(2, response.getTags().size());
+    }
+
+    private static Idea buildIdea(String description) {
+        Idea idea = new Idea();
+        idea.setId(1L);
+        idea.setTitle("title");
+        idea.setDescription(description);
+        idea.setImages(List.of("img1"));
+        idea.setCreatedAt(LocalDateTime.of(2024, 1, 1, 0, 0));
+        idea.setLikeCount(0L);
+        idea.setCommentCount(0L);
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("user1");
+        user.setAvatar("avatar.png");
+        idea.setUser(user);
+
+        Tag tag1 = new Tag();
+        tag1.setName("tag1");
+        Tag tag2 = new Tag();
+        tag2.setName("tag2");
+        Set<Tag> tags = new HashSet<>();
+        tags.add(tag1);
+        tags.add(tag2);
+        idea.setTags(tags);
+        return idea;
+    }
+
+    private static String repeat(String value, int count) {
+        return value.repeat(count);
+    }
+}

--- a/idea_back/src/test/java/com/learn/demo/dto/idea/IdeaQueryRequestTest.java
+++ b/idea_back/src/test/java/com/learn/demo/dto/idea/IdeaQueryRequestTest.java
@@ -1,0 +1,74 @@
+package com.learn.demo.dto.idea;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class IdeaQueryRequestTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void defaultValuesAppliedInNoArgsConstructor() {
+        IdeaQueryRequest request = new IdeaQueryRequest();
+        assertEquals(0, request.getPage());
+        assertEquals(20, request.getSize());
+        assertEquals("createdAt,desc", request.getSort());
+    }
+
+    @Test
+    void defaultValuesAppliedInBuilder() {
+        IdeaQueryRequest request = IdeaQueryRequest.builder().build();
+        assertEquals(0, request.getPage());
+        assertEquals(20, request.getSize());
+        assertEquals("createdAt,desc", request.getSort());
+    }
+
+    @Test
+    void sizeAboveMaxFailsValidation() {
+        IdeaQueryRequest request = IdeaQueryRequest.builder()
+            .size(101)
+            .build();
+
+        Set<ConstraintViolation<IdeaQueryRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("size", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void sizeAtMaxPassesValidation() {
+        IdeaQueryRequest request = IdeaQueryRequest.builder()
+            .size(100)
+            .build();
+
+        Set<ConstraintViolation<IdeaQueryRequest>> violations = validator.validate(request);
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    void nullableFiltersDoNotFailValidation() {
+        IdeaQueryRequest request = IdeaQueryRequest.builder()
+            .keyword(null)
+            .tag(null)
+            .userId(null)
+            .build();
+
+        Set<ConstraintViolation<IdeaQueryRequest>> violations = validator.validate(request);
+        assertTrue(violations.isEmpty());
+        assertNull(request.getKeyword());
+        assertNull(request.getTag());
+        assertNull(request.getUserId());
+    }
+}

--- a/idea_back/src/test/java/com/learn/demo/dto/idea/UpdateIdeaRequestTest.java
+++ b/idea_back/src/test/java/com/learn/demo/dto/idea/UpdateIdeaRequestTest.java
@@ -1,0 +1,130 @@
+package com.learn.demo.dto.idea;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class UpdateIdeaRequestTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void validRequestPassesValidation() {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("a")
+            .description("b")
+            .images(List.of())
+            .tags(List.of("tag"))
+            .build();
+
+        Set<ConstraintViolation<UpdateIdeaRequest>> violations = validator.validate(request);
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    void blankTitleFailsValidation() {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title(" ")
+            .description("desc")
+            .build();
+
+        Set<ConstraintViolation<UpdateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("title", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void titleTooLongFailsValidation() {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title(repeat("a", 101))
+            .description("desc")
+            .build();
+
+        Set<ConstraintViolation<UpdateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("title", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void descriptionTooLongFailsValidation() {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("title")
+            .description(repeat("a", 5001))
+            .build();
+
+        Set<ConstraintViolation<UpdateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("description", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void tooManyImagesFailsValidation() {
+        List<String> images = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            images.add("img" + i);
+        }
+
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("title")
+            .description("desc")
+            .images(images)
+            .build();
+
+        Set<ConstraintViolation<UpdateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("images", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void nullTitleFailsValidation() {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title(null)
+            .description("desc")
+            .build();
+
+        Set<ConstraintViolation<UpdateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("title", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void nullDescriptionFailsValidation() {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("title")
+            .description(null)
+            .build();
+
+        Set<ConstraintViolation<UpdateIdeaRequest>> violations = validator.validate(request);
+        assertEquals(1, violations.size());
+        assertEquals("description", violations.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    void boundaryLengthsPassValidation() {
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title(repeat("a", 100))
+            .description(repeat("b", 5000))
+            .images(List.of("1", "2", "3", "4", "5", "6", "7", "8", "9"))
+            .build();
+
+        Set<ConstraintViolation<UpdateIdeaRequest>> violations = validator.validate(request);
+        assertTrue(violations.isEmpty());
+    }
+
+    private static String repeat(String value, int count) {
+        return value.repeat(count);
+    }
+}

--- a/idea_back/src/test/java/com/learn/demo/integration/IdeaCrudIntegrationTest.java
+++ b/idea_back/src/test/java/com/learn/demo/integration/IdeaCrudIntegrationTest.java
@@ -1,0 +1,373 @@
+package com.learn.demo.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.learn.demo.dto.idea.CreateIdeaRequest;
+import com.learn.demo.dto.idea.UpdateIdeaRequest;
+import com.learn.demo.entity.Idea;
+import com.learn.demo.entity.Like;
+import com.learn.demo.entity.Tag;
+import com.learn.demo.entity.User;
+import com.learn.demo.enums.IdeaStatus;
+import com.learn.demo.enums.UserRole;
+import com.learn.demo.enums.UserStatus;
+import com.learn.demo.repository.IdeaRepository;
+import com.learn.demo.repository.LikeRepository;
+import com.learn.demo.repository.TagRepository;
+import com.learn.demo.repository.UserRepository;
+import com.learn.demo.security.JwtTokenProvider;
+import com.learn.demo.security.UserPrincipal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+class IdeaCrudIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private IdeaRepository ideaRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    void fullCrudWorkflowUpdatesTagsAndSnippet() throws Exception {
+        User author = saveUser("author", UserRole.USER);
+        String longDescription = "x".repeat(220);
+        CreateIdeaRequest createRequest = CreateIdeaRequest.builder()
+            .title("First Idea")
+            .description(longDescription)
+            .images(List.of("img1"))
+            .tags(List.of("Spring", "Java"))
+            .build();
+
+        MvcResult createResult = mockMvc.perform(post("/api/ideas")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", bearer(author))
+                .content(objectMapper.writeValueAsString(createRequest)))
+            .andExpect(status().isCreated())
+            .andReturn();
+        Long ideaId = readJson(createResult).path("data").path("id").asLong();
+
+        MvcResult listResult = mockMvc.perform(get("/api/ideas")
+                .header("Authorization", bearer(author)))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode listContent = readJson(listResult).path("data").path("content");
+        assertEquals(1, listContent.size());
+        String snippet = listContent.get(0).path("description").asText();
+        assertEquals(200, snippet.length());
+
+        String updatedDescription = "y".repeat(260);
+        UpdateIdeaRequest updateRequest = UpdateIdeaRequest.builder()
+            .title("Updated")
+            .description(updatedDescription)
+            .images(List.of("img2"))
+            .tags(List.of("Java", "DB"))
+            .build();
+        mockMvc.perform(put("/api/ideas/" + ideaId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", bearer(author))
+                .content(objectMapper.writeValueAsString(updateRequest)))
+            .andExpect(status().isOk());
+
+        Tag spring = tagRepository.findByNameIgnoreCase("Spring").orElseThrow();
+        Tag java = tagRepository.findByNameIgnoreCase("Java").orElseThrow();
+        Tag db = tagRepository.findByNameIgnoreCase("DB").orElseThrow();
+        assertEquals(0L, spring.getUsageCount());
+        assertEquals(1L, java.getUsageCount());
+        assertEquals(1L, db.getUsageCount());
+
+        MvcResult detailResult = mockMvc.perform(get("/api/ideas/" + ideaId)
+                .header("Authorization", bearer(author)))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode detail = readJson(detailResult).path("data");
+        assertEquals(updatedDescription, detail.path("description").asText());
+        Set<String> detailTags = toStringSet(detail.path("tags"));
+        assertTrue(detailTags.contains("Java"));
+        assertTrue(detailTags.contains("DB"));
+
+        mockMvc.perform(delete("/api/ideas/" + ideaId)
+                .header("Authorization", bearer(author)))
+            .andExpect(status().isOk());
+
+        MvcResult afterDelete = mockMvc.perform(get("/api/ideas")
+                .header("Authorization", bearer(author)))
+            .andExpect(status().isOk())
+            .andReturn();
+        assertEquals(0, readJson(afterDelete).path("data").path("totalElements").asLong());
+
+        Idea deleted = ideaRepository.findById(ideaId).orElseThrow();
+        assertEquals(IdeaStatus.DELETED, deleted.getStatus());
+        Tag javaAfterDelete = tagRepository.findByNameIgnoreCase("Java").orElseThrow();
+        Tag dbAfterDelete = tagRepository.findByNameIgnoreCase("DB").orElseThrow();
+        assertEquals(0L, javaAfterDelete.getUsageCount());
+        assertEquals(0L, dbAfterDelete.getUsageCount());
+    }
+
+    @Test
+    void permissionEnforcementBlocksNonOwnerAllowsAdmin() throws Exception {
+        User author = saveUser("owner", UserRole.USER);
+        User other = saveUser("other", UserRole.USER);
+        User admin = saveUser("admin", UserRole.ADMIN);
+        Idea idea = saveIdea(author, "Idea", "Desc", Set.of());
+
+        UpdateIdeaRequest updateRequest = UpdateIdeaRequest.builder()
+            .title("New")
+            .description("New Desc")
+            .build();
+
+        mockMvc.perform(put("/api/ideas/" + idea.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", bearer(other))
+                .content(objectMapper.writeValueAsString(updateRequest)))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value(403))
+            .andExpect(jsonPath("$.message").value("Forbidden"));
+
+        mockMvc.perform(delete("/api/ideas/" + idea.getId())
+                .header("Authorization", bearer(other)))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value(403))
+            .andExpect(jsonPath("$.message").value("Forbidden"));
+
+        mockMvc.perform(delete("/api/ideas/" + idea.getId())
+                .header("Authorization", bearer(admin)))
+            .andExpect(status().isOk());
+
+        Idea deleted = ideaRepository.findById(idea.getId()).orElseThrow();
+        assertEquals(IdeaStatus.DELETED, deleted.getStatus());
+    }
+
+    @Test
+    void paginationAndSortingWorkAcrossPages() throws Exception {
+        User user = saveUser("pager", UserRole.USER);
+
+        MvcResult emptyResult = mockMvc.perform(get("/api/ideas")
+                .header("Authorization", bearer(user)))
+            .andExpect(status().isOk())
+            .andReturn();
+        assertEquals(0, readJson(emptyResult).path("data").path("totalElements").asLong());
+
+        for (int i = 0; i < 25; i++) {
+            Idea idea = saveIdea(user, "Idea " + i, "Desc " + i, Set.of());
+            idea.setLikeCount((long) i);
+            ideaRepository.save(idea);
+        }
+
+        MvcResult page0 = mockMvc.perform(get("/api/ideas")
+                .param("page", "0")
+                .param("size", "10")
+                .header("Authorization", bearer(user)))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode page0Data = readJson(page0).path("data");
+        assertEquals(25, page0Data.path("totalElements").asLong());
+        assertEquals(3, page0Data.path("totalPages").asInt());
+        assertEquals(10, page0Data.path("content").size());
+
+        MvcResult page2 = mockMvc.perform(get("/api/ideas")
+                .param("page", "2")
+                .param("size", "10")
+                .header("Authorization", bearer(user)))
+            .andExpect(status().isOk())
+            .andReturn();
+        assertEquals(5, readJson(page2).path("data").path("content").size());
+
+        MvcResult likeSorted = mockMvc.perform(get("/api/ideas")
+                .param("sort", "likeCount,asc")
+                .param("size", "5")
+                .header("Authorization", bearer(user)))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode likeContent = readJson(likeSorted).path("data").path("content");
+        long firstLike = likeContent.get(0).path("likeCount").asLong();
+        long lastLike = likeContent.get(likeContent.size() - 1).path("likeCount").asLong();
+        assertTrue(firstLike <= lastLike);
+
+        MvcResult createdAtSorted = mockMvc.perform(get("/api/ideas")
+                .param("sort", "createdAt,asc")
+                .param("size", "5")
+                .header("Authorization", bearer(user)))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode createdContent = readJson(createdAtSorted).path("data").path("content");
+        LocalDateTime firstCreated = LocalDateTime.parse(createdContent.get(0).path("createdAt").asText());
+        LocalDateTime lastCreated = LocalDateTime.parse(createdContent.get(createdContent.size() - 1)
+            .path("createdAt").asText());
+        assertTrue(!firstCreated.isAfter(lastCreated));
+    }
+
+    @Test
+    void filteringByKeywordTagAndUserIdWorks() throws Exception {
+        User user1 = saveUser("filter1", UserRole.USER);
+        User user2 = saveUser("filter2", UserRole.USER);
+        Tag java = saveTag("java", 2L);
+        Tag spring = saveTag("spring", 1L);
+
+        Idea alpha = saveIdea(user1, "Alpha Idea", "Something", Set.of(java));
+        Idea beta = saveIdea(user1, "Other", "Contains Beta", Set.of(spring));
+        Idea gamma = saveIdea(user2, "Gamma", "Another", Set.of(java));
+
+        MvcResult keywordTitle = mockMvc.perform(get("/api/ideas")
+                .param("keyword", "alpha")
+                .header("Authorization", bearer(user1)))
+            .andExpect(status().isOk())
+            .andReturn();
+        List<Long> titleIds = toIdList(readJson(keywordTitle).path("data").path("content"));
+        assertEquals(1, titleIds.size());
+        assertTrue(titleIds.contains(alpha.getId()));
+
+        MvcResult keywordDesc = mockMvc.perform(get("/api/ideas")
+                .param("keyword", "beta")
+                .header("Authorization", bearer(user1)))
+            .andExpect(status().isOk())
+            .andReturn();
+        List<Long> descIds = toIdList(readJson(keywordDesc).path("data").path("content"));
+        assertEquals(1, descIds.size());
+        assertTrue(descIds.contains(beta.getId()));
+
+        MvcResult tagFilter = mockMvc.perform(get("/api/ideas")
+                .param("tag", "java")
+                .header("Authorization", bearer(user1)))
+            .andExpect(status().isOk())
+            .andReturn();
+        List<Long> tagIds = toIdList(readJson(tagFilter).path("data").path("content"));
+        assertEquals(2, tagIds.size());
+        assertTrue(tagIds.contains(alpha.getId()));
+        assertTrue(tagIds.contains(gamma.getId()));
+
+        MvcResult userFilter = mockMvc.perform(get("/api/ideas")
+                .param("userId", user1.getId().toString())
+                .header("Authorization", bearer(user1)))
+            .andExpect(status().isOk())
+            .andReturn();
+        List<Long> userIds = toIdList(readJson(userFilter).path("data").path("content"));
+        assertEquals(2, userIds.size());
+        assertTrue(userIds.contains(alpha.getId()));
+        assertTrue(userIds.contains(beta.getId()));
+    }
+
+    @Test
+    void likedStatusReflectsUserLikes() throws Exception {
+        User user = saveUser("liker", UserRole.USER);
+        Idea idea = saveIdea(user, "Idea", "Desc", Set.of());
+
+        MvcResult noLike = mockMvc.perform(get("/api/ideas")
+                .header("Authorization", bearer(user)))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode noLikeContent = readJson(noLike).path("data").path("content");
+        assertFalse(noLikeContent.get(0).path("liked").asBoolean());
+
+        Like like = new Like();
+        like.setUser(user);
+        like.setIdea(idea);
+        likeRepository.save(like);
+
+        MvcResult withLike = mockMvc.perform(get("/api/ideas")
+                .header("Authorization", bearer(user)))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode withLikeContent = readJson(withLike).path("data").path("content");
+        assertTrue(withLikeContent.get(0).path("liked").asBoolean());
+    }
+
+    private User saveUser(String username, UserRole role) {
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword("password");
+        user.setRole(role);
+        user.setStatus(UserStatus.ACTIVE);
+        return userRepository.save(user);
+    }
+
+    private String bearer(User user) {
+        return "Bearer " + jwtTokenProvider.generateToken(new UserPrincipal(user));
+    }
+
+    private Idea saveIdea(User user, String title, String description, Set<Tag> tags) {
+        Idea idea = new Idea();
+        idea.setUser(user);
+        idea.setTitle(title);
+        idea.setDescription(description);
+        idea.setImages(List.of());
+        idea.setStatus(IdeaStatus.ACTIVE);
+        idea.setTags(new HashSet<>(tags));
+        idea.setLikeCount(0L);
+        idea.setCommentCount(0L);
+        return ideaRepository.save(idea);
+    }
+
+    private Tag saveTag(String name, long usageCount) {
+        Tag tag = new Tag();
+        tag.setName(name);
+        tag.setUsageCount(usageCount);
+        return tagRepository.save(tag);
+    }
+
+    private JsonNode readJson(MvcResult result) throws Exception {
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    private List<Long> toIdList(JsonNode content) {
+        List<Long> ids = new ArrayList<>();
+        for (JsonNode node : content) {
+            ids.add(node.path("id").asLong());
+        }
+        return ids;
+    }
+
+    private Set<String> toStringSet(JsonNode array) {
+        return streamArray(array).collect(Collectors.toSet());
+    }
+
+    private java.util.stream.Stream<String> streamArray(JsonNode array) {
+        List<String> values = new ArrayList<>();
+        for (JsonNode node : array) {
+            values.add(node.asText());
+        }
+        return values.stream();
+    }
+}

--- a/idea_back/src/test/java/com/learn/demo/repository/IdeaRepositoryTest.java
+++ b/idea_back/src/test/java/com/learn/demo/repository/IdeaRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.learn.demo.entity.Idea;
 import com.learn.demo.entity.User;
 import com.learn.demo.enums.IdeaStatus;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
@@ -76,6 +77,33 @@ class IdeaRepositoryTest {
 
         Page<Idea> page = ideaRepository.searchByKeyword("Missing", PageRequest.of(0, 10));
         assertEquals(0, page.getTotalElements());
+    }
+
+    @Test
+    void findByUserIdAndIdAndStatusMatchesOwnerAndStatus() {
+        User owner = userRepository.save(buildUser("own", "own@example.com"));
+        User other = userRepository.save(buildUser("other", "other2@example.com"));
+        Idea idea = ideaRepository.save(buildIdea(owner, "Idea", "Desc", IdeaStatus.ACTIVE));
+
+        Optional<Idea> ownerMatch = ideaRepository.findByUserIdAndIdAndStatus(
+            owner.getId(),
+            idea.getId(),
+            IdeaStatus.ACTIVE
+        );
+        Optional<Idea> otherMatch = ideaRepository.findByUserIdAndIdAndStatus(
+            other.getId(),
+            idea.getId(),
+            IdeaStatus.ACTIVE
+        );
+        Optional<Idea> statusMismatch = ideaRepository.findByUserIdAndIdAndStatus(
+            owner.getId(),
+            idea.getId(),
+            IdeaStatus.HIDDEN
+        );
+
+        assertTrue(ownerMatch.isPresent());
+        assertTrue(otherMatch.isEmpty());
+        assertTrue(statusMismatch.isEmpty());
     }
 
     private User buildUser(String username, String email) {

--- a/idea_back/src/test/java/com/learn/demo/repository/LikeRepositoryTest.java
+++ b/idea_back/src/test/java/com/learn/demo/repository/LikeRepositoryTest.java
@@ -8,6 +8,7 @@ import com.learn.demo.entity.Idea;
 import com.learn.demo.entity.Like;
 import com.learn.demo.entity.User;
 import com.learn.demo.enums.IdeaStatus;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,6 +73,54 @@ class LikeRepositoryTest {
     void findByUserIdAndIdeaIdReturnsEmptyWhenMissing() {
         Optional<Like> found = likeRepository.findByUserIdAndIdeaId(1L, 2L);
         assertTrue(found.isEmpty());
+    }
+
+    @Test
+    void findByUserIdAndIdeaIdInHandlesEmptyList() {
+        User user = userRepository.save(buildUser("batch", "batch@example.com"));
+        List<Like> likes = likeRepository.findByUserIdAndIdeaIdIn(user.getId(), List.of());
+        assertTrue(likes.isEmpty());
+    }
+
+    @Test
+    void findByUserIdAndIdeaIdInReturnsOnlyUserLikes() {
+        User user = userRepository.save(buildUser("batch2", "batch2@example.com"));
+        User other = userRepository.save(buildUser("batch3", "batch3@example.com"));
+        Idea idea1 = ideaRepository.save(buildIdea(user, "Idea1", "Desc1"));
+        Idea idea2 = ideaRepository.save(buildIdea(user, "Idea2", "Desc2"));
+        likeRepository.save(buildLike(user, idea1));
+        likeRepository.save(buildLike(other, idea2));
+
+        List<Like> likes = likeRepository.findByUserIdAndIdeaIdIn(
+            user.getId(),
+            List.of(idea1.getId(), idea2.getId())
+        );
+
+        assertEquals(1, likes.size());
+        assertTrue(likes.stream().allMatch(like -> like.getUser().getId().equals(user.getId())));
+        assertTrue(likes.stream().allMatch(like -> like.getIdea().getId().equals(idea1.getId())));
+    }
+
+    @Test
+    void findByUserIdAndIdeaIdInIgnoresMissingIdeas() {
+        User user = userRepository.save(buildUser("batch4", "batch4@example.com"));
+        Idea idea = ideaRepository.save(buildIdea(user, "Idea3", "Desc3"));
+        likeRepository.save(buildLike(user, idea));
+
+        List<Like> likes = likeRepository.findByUserIdAndIdeaIdIn(
+            user.getId(),
+            List.of(idea.getId(), 999L)
+        );
+
+        assertEquals(1, likes.size());
+        assertTrue(likes.stream().anyMatch(like -> like.getIdea().getId().equals(idea.getId())));
+    }
+
+    @Test
+    void findByUserIdAndIdeaIdInReturnsEmptyWhenNoMatches() {
+        User user = userRepository.save(buildUser("batch5", "batch5@example.com"));
+        List<Like> likes = likeRepository.findByUserIdAndIdeaIdIn(user.getId(), List.of(999L, 1000L));
+        assertTrue(likes.isEmpty());
     }
 
     private User buildUser(String username, String email) {

--- a/idea_back/src/test/java/com/learn/demo/service/IdeaServiceTest.java
+++ b/idea_back/src/test/java/com/learn/demo/service/IdeaServiceTest.java
@@ -1,0 +1,343 @@
+package com.learn.demo.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.learn.demo.dto.PageResponse;
+import com.learn.demo.dto.idea.CreateIdeaRequest;
+import com.learn.demo.dto.idea.IdeaDetailResponse;
+import com.learn.demo.dto.idea.IdeaListResponse;
+import com.learn.demo.dto.idea.IdeaQueryRequest;
+import com.learn.demo.dto.idea.UpdateIdeaRequest;
+import com.learn.demo.entity.Idea;
+import com.learn.demo.entity.Like;
+import com.learn.demo.entity.Tag;
+import com.learn.demo.entity.User;
+import com.learn.demo.enums.IdeaStatus;
+import com.learn.demo.exception.BusinessException;
+import com.learn.demo.repository.IdeaRepository;
+import com.learn.demo.repository.LikeRepository;
+import com.learn.demo.repository.TagRepository;
+import com.learn.demo.repository.UserRepository;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+
+@ExtendWith(MockitoExtension.class)
+class IdeaServiceTest {
+
+    @Mock
+    private IdeaRepository ideaRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TagRepository tagRepository;
+    @Mock
+    private LikeRepository likeRepository;
+
+    @InjectMocks
+    private IdeaService ideaService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = buildUser(1L, "alice");
+    }
+
+    @Test
+    void listIdeasEmptyDoesNotQueryLikesWhenUserNull() {
+        IdeaQueryRequest request = IdeaQueryRequest.builder().build();
+        when(ideaRepository.findAll(any(Specification.class), any(Pageable.class))).thenAnswer(invocation -> {
+            Pageable pageable = invocation.getArgument(1);
+            return new PageImpl<>(List.of(), pageable, 0);
+        });
+
+        PageResponse<IdeaListResponse> response = ideaService.listIdeas(request, null);
+
+        assertTrue(response.getContent().isEmpty());
+        assertEquals(0, response.getTotalElements());
+        verify(likeRepository, never()).findByUserIdAndIdeaIdIn(anyLong(), anyList());
+    }
+
+    @Test
+    void listIdeasUsesSortByLikeCount() {
+        IdeaQueryRequest request = IdeaQueryRequest.builder()
+            .sort("likeCount,asc")
+            .build();
+        when(ideaRepository.findAll(any(Specification.class), any(Pageable.class))).thenAnswer(invocation -> {
+            Pageable pageable = invocation.getArgument(1);
+            return new PageImpl<>(List.of(), pageable, 0);
+        });
+
+        ideaService.listIdeas(request, 9L);
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(ideaRepository).findAll(any(Specification.class), captor.capture());
+        Pageable pageable = captor.getValue();
+        Sort.Order order = pageable.getSort().getOrderFor("likeCount");
+        assertNotNull(order);
+        assertEquals(Sort.Direction.ASC, order.getDirection());
+    }
+
+    @Test
+    void listIdeasMapsLikedFlags() {
+        IdeaQueryRequest request = IdeaQueryRequest.builder().build();
+        Idea idea1 = buildIdea(1L, user, IdeaStatus.ACTIVE, Set.of());
+        Idea idea2 = buildIdea(2L, user, IdeaStatus.ACTIVE, Set.of());
+        Page<Idea> page = new PageImpl<>(
+            List.of(idea1, idea2),
+            PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt")),
+            2
+        );
+        when(ideaRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
+        Like like = new Like();
+        like.setId(7L);
+        like.setUser(user);
+        like.setIdea(idea2);
+        when(likeRepository.findByUserIdAndIdeaIdIn(eq(5L), eq(List.of(1L, 2L))))
+            .thenReturn(List.of(like));
+
+        PageResponse<IdeaListResponse> response = ideaService.listIdeas(request, 5L);
+
+        assertEquals(2, response.getContent().size());
+        assertFalse(response.getContent().get(0).isLiked());
+        assertTrue(response.getContent().get(1).isLiked());
+    }
+
+    @Test
+    void getIdeaDetailNotFoundThrows404() {
+        when(ideaRepository.findById(99L)).thenReturn(Optional.empty());
+
+        BusinessException ex = assertThrows(BusinessException.class, () -> ideaService.getIdeaDetail(99L, 1L));
+
+        assertEquals(404, ex.getCode());
+    }
+
+    @Test
+    void getIdeaDetailDeletedThrows404() {
+        Idea idea = buildIdea(3L, user, IdeaStatus.DELETED, Set.of());
+        when(ideaRepository.findById(3L)).thenReturn(Optional.of(idea));
+
+        BusinessException ex = assertThrows(BusinessException.class, () -> ideaService.getIdeaDetail(3L, 1L));
+
+        assertEquals(404, ex.getCode());
+    }
+
+    @Test
+    void getIdeaDetailReturnsLikedStatus() {
+        Idea idea = buildIdea(4L, user, IdeaStatus.ACTIVE, Set.of());
+        when(ideaRepository.findById(4L)).thenReturn(Optional.of(idea));
+        when(likeRepository.existsByUserIdAndIdeaId(2L, 4L)).thenReturn(true);
+
+        IdeaDetailResponse response = ideaService.getIdeaDetail(4L, 2L);
+
+        assertTrue(response.isLiked());
+    }
+
+    @Test
+    void createIdeaCreatesNewAndExistingTags() {
+        CreateIdeaRequest request = CreateIdeaRequest.builder()
+            .title("Title")
+            .description("Desc")
+            .images(List.of("img1"))
+            .tags(Arrays.asList(" Green ", "green", "", null, "Blue"))
+            .build();
+        Tag green = buildTag(10L, "Green", 2L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(tagRepository.findByNameIgnoreCase("Green")).thenReturn(Optional.of(green));
+        when(tagRepository.findByNameIgnoreCase("Blue")).thenReturn(Optional.empty());
+        when(tagRepository.save(any(Tag.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(ideaRepository.save(any(Idea.class))).thenAnswer(invocation -> {
+            Idea saved = invocation.getArgument(0);
+            saved.setId(100L);
+            return saved;
+        });
+
+        IdeaDetailResponse response = ideaService.createIdea(request, 1L);
+
+        assertEquals(100L, response.getId());
+        ArgumentCaptor<Idea> ideaCaptor = ArgumentCaptor.forClass(Idea.class);
+        verify(ideaRepository).save(ideaCaptor.capture());
+        Idea saved = ideaCaptor.getValue();
+        assertEquals(IdeaStatus.ACTIVE, saved.getStatus());
+        assertEquals("Title", saved.getTitle());
+        assertEquals(2, saved.getTags().size());
+        verify(tagRepository, times(1)).findByNameIgnoreCase("Green");
+        verify(tagRepository, times(1)).findByNameIgnoreCase("Blue");
+
+        ArgumentCaptor<Tag> tagCaptor = ArgumentCaptor.forClass(Tag.class);
+        verify(tagRepository, times(2)).save(tagCaptor.capture());
+        List<Tag> savedTags = tagCaptor.getAllValues();
+        Tag savedGreen = savedTags.stream().filter(t -> "Green".equals(t.getName())).findFirst().orElse(null);
+        Tag savedBlue = savedTags.stream().filter(t -> "Blue".equals(t.getName())).findFirst().orElse(null);
+        assertNotNull(savedGreen);
+        assertNotNull(savedBlue);
+        assertEquals(3L, savedGreen.getUsageCount());
+        assertEquals(1L, savedBlue.getUsageCount());
+    }
+
+    @Test
+    void updateIdeaNonAuthorThrows403() {
+        Idea idea = buildIdea(5L, user, IdeaStatus.ACTIVE, Set.of());
+        when(ideaRepository.findById(5L)).thenReturn(Optional.of(idea));
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("T")
+            .description("D")
+            .build();
+
+        BusinessException ex = assertThrows(BusinessException.class, () -> ideaService.updateIdea(5L, request, 2L));
+
+        assertEquals(403, ex.getCode());
+    }
+
+    @Test
+    void updateIdeaDeletedThrows404() {
+        Idea idea = buildIdea(6L, user, IdeaStatus.DELETED, Set.of());
+        when(ideaRepository.findById(6L)).thenReturn(Optional.of(idea));
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("T")
+            .description("D")
+            .build();
+
+        BusinessException ex = assertThrows(BusinessException.class, () -> ideaService.updateIdea(6L, request, 1L));
+
+        assertEquals(404, ex.getCode());
+    }
+
+    @Test
+    void updateIdeaSyncsTags() {
+        Tag tagA = buildTag(1L, "A", 2L);
+        Tag tagB = buildTag(2L, "B", 3L);
+        Tag tagC = buildTag(3L, "C", 5L);
+        Idea idea = buildIdea(7L, user, IdeaStatus.ACTIVE, new HashSet<>(Set.of(tagA, tagB)));
+        when(ideaRepository.findById(7L)).thenReturn(Optional.of(idea));
+        when(tagRepository.findByNameIgnoreCase("C")).thenReturn(Optional.of(tagC));
+        when(tagRepository.save(any(Tag.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(ideaRepository.save(any(Idea.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        UpdateIdeaRequest request = UpdateIdeaRequest.builder()
+            .title("New")
+            .description("New Desc")
+            .tags(List.of("B", "C"))
+            .build();
+
+        IdeaDetailResponse response = ideaService.updateIdea(7L, request, 1L);
+
+        assertEquals(2, response.getTags().size());
+        assertEquals(1L, tagA.getUsageCount());
+        assertEquals(3L, tagB.getUsageCount());
+        assertEquals(6L, tagC.getUsageCount());
+        ArgumentCaptor<Tag> tagCaptor = ArgumentCaptor.forClass(Tag.class);
+        verify(tagRepository, times(2)).save(tagCaptor.capture());
+        List<Tag> savedTags = tagCaptor.getAllValues();
+        assertTrue(savedTags.contains(tagA));
+        assertTrue(savedTags.contains(tagC));
+    }
+
+    @Test
+    void deleteIdeaAuthorSoftDeletesAndDecrementsTags() {
+        Tag tagA = buildTag(1L, "A", 1L);
+        Tag tagB = buildTag(2L, "B", 0L);
+        Idea idea = buildIdea(8L, user, IdeaStatus.ACTIVE, Set.of(tagA, tagB));
+        when(ideaRepository.findById(8L)).thenReturn(Optional.of(idea));
+        when(tagRepository.save(any(Tag.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ideaService.deleteIdea(8L, 1L, false);
+
+        assertEquals(IdeaStatus.DELETED, idea.getStatus());
+        assertEquals(0L, tagA.getUsageCount());
+        assertEquals(0L, tagB.getUsageCount());
+        verify(tagRepository, times(2)).save(any(Tag.class));
+        verify(ideaRepository).save(idea);
+    }
+
+    @Test
+    void deleteIdeaNonAuthorNonAdminThrows403() {
+        Idea idea = buildIdea(9L, user, IdeaStatus.ACTIVE, Set.of());
+        when(ideaRepository.findById(9L)).thenReturn(Optional.of(idea));
+
+        BusinessException ex = assertThrows(
+            BusinessException.class,
+            () -> ideaService.deleteIdea(9L, 2L, false)
+        );
+
+        assertEquals(403, ex.getCode());
+    }
+
+    @Test
+    void deleteIdeaAdminBypassAllowed() {
+        Idea idea = buildIdea(10L, user, IdeaStatus.ACTIVE, Set.of());
+        when(ideaRepository.findById(10L)).thenReturn(Optional.of(idea));
+
+        ideaService.deleteIdea(10L, 2L, true);
+
+        assertEquals(IdeaStatus.DELETED, idea.getStatus());
+        verify(ideaRepository).save(idea);
+    }
+
+    @Test
+    void getCurrentUserIdeasSetsUserId() {
+        IdeaQueryRequest request = IdeaQueryRequest.builder().build();
+        when(ideaRepository.findAll(any(Specification.class), any(Pageable.class))).thenAnswer(invocation -> {
+            Pageable pageable = invocation.getArgument(1);
+            return new PageImpl<>(List.of(), pageable, 0);
+        });
+
+        ideaService.getCurrentUserIdeas(request, 42L);
+
+        assertEquals(42L, request.getUserId());
+    }
+
+    private User buildUser(Long id, String username) {
+        User u = new User();
+        u.setId(id);
+        u.setUsername(username);
+        u.setPassword("pw");
+        return u;
+    }
+
+    private Idea buildIdea(Long id, User owner, IdeaStatus status, Set<Tag> tags) {
+        Idea idea = new Idea();
+        idea.setId(id);
+        idea.setUser(owner);
+        idea.setTitle("Title " + id);
+        idea.setDescription("Desc " + id);
+        idea.setStatus(status);
+        idea.setTags(tags);
+        return idea;
+    }
+
+    private Tag buildTag(Long id, String name, long usageCount) {
+        Tag tag = new Tag();
+        tag.setId(id);
+        tag.setName(name);
+        tag.setUsageCount(usageCount);
+        return tag;
+    }
+}

--- a/idea_back/src/test/java/com/learn/demo/specification/IdeaSpecificationsTest.java
+++ b/idea_back/src/test/java/com/learn/demo/specification/IdeaSpecificationsTest.java
@@ -1,0 +1,119 @@
+package com.learn.demo.specification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.learn.demo.dto.idea.IdeaQueryRequest;
+import com.learn.demo.entity.Idea;
+import com.learn.demo.entity.Tag;
+import com.learn.demo.entity.User;
+import com.learn.demo.enums.IdeaStatus;
+import com.learn.demo.repository.IdeaRepository;
+import com.learn.demo.repository.TagRepository;
+import com.learn.demo.repository.UserRepository;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class IdeaSpecificationsTest {
+
+    @Autowired
+    private IdeaRepository ideaRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Test
+    void combineFiltersByKeywordAndExcludesDeleted() {
+        User user = userRepository.save(buildUser("kwd", "kw@example.com"));
+        ideaRepository.save(buildIdea(user, "Solar Grid", "clean energy", IdeaStatus.ACTIVE, Set.of()));
+        ideaRepository.save(buildIdea(user, "Wind", "Solar panels", IdeaStatus.HIDDEN, Set.of()));
+        ideaRepository.save(buildIdea(user, "Solar", "deleted", IdeaStatus.DELETED, Set.of()));
+
+        IdeaQueryRequest request = IdeaQueryRequest.builder().keyword("solar").build();
+        List<Idea> results = ideaRepository.findAll(IdeaSpecifications.combine(request));
+
+        assertEquals(2, results.size());
+        assertTrue(results.stream().noneMatch(idea -> idea.getStatus() == IdeaStatus.DELETED));
+    }
+
+    @Test
+    void combineFiltersByTag() {
+        User user = userRepository.save(buildUser("tag", "tag@example.com"));
+        Tag green = tagRepository.save(buildTag("Green"));
+        Tag blue = tagRepository.save(buildTag("Blue"));
+
+        ideaRepository.save(buildIdea(user, "Idea1", "Desc", IdeaStatus.ACTIVE, Set.of(green)));
+        ideaRepository.save(buildIdea(user, "Idea2", "Desc", IdeaStatus.DELETED, Set.of(green)));
+        ideaRepository.save(buildIdea(user, "Idea3", "Desc", IdeaStatus.ACTIVE, Set.of(blue)));
+
+        IdeaQueryRequest request = IdeaQueryRequest.builder().tag("green").build();
+        List<Idea> results = ideaRepository.findAll(IdeaSpecifications.combine(request));
+
+        assertEquals(1, results.size());
+        assertTrue(results.stream().allMatch(idea -> idea.getTags().contains(green)));
+    }
+
+    @Test
+    void combineFiltersByUserId() {
+        User owner = userRepository.save(buildUser("owner", "owner@spec.com"));
+        User other = userRepository.save(buildUser("other", "other@spec.com"));
+
+        ideaRepository.save(buildIdea(owner, "Idea1", "Desc", IdeaStatus.ACTIVE, Set.of()));
+        ideaRepository.save(buildIdea(owner, "Idea2", "Desc", IdeaStatus.DELETED, Set.of()));
+        ideaRepository.save(buildIdea(other, "Idea3", "Desc", IdeaStatus.ACTIVE, Set.of()));
+
+        IdeaQueryRequest request = IdeaQueryRequest.builder().userId(owner.getId()).build();
+        List<Idea> results = ideaRepository.findAll(IdeaSpecifications.combine(request));
+
+        assertEquals(1, results.size());
+        assertTrue(results.stream().allMatch(idea -> idea.getUser().getId().equals(owner.getId())));
+    }
+
+    @Test
+    void combineExcludesDeletedWhenNoFiltersProvided() {
+        User user = userRepository.save(buildUser("plain", "plain@example.com"));
+        ideaRepository.save(buildIdea(user, "Idea1", "Desc", IdeaStatus.ACTIVE, Set.of()));
+        ideaRepository.save(buildIdea(user, "Idea2", "Desc", IdeaStatus.HIDDEN, Set.of()));
+        ideaRepository.save(buildIdea(user, "Idea3", "Desc", IdeaStatus.DELETED, Set.of()));
+
+        IdeaQueryRequest request = IdeaQueryRequest.builder().build();
+        List<Idea> results = ideaRepository.findAll(IdeaSpecifications.combine(request));
+
+        assertEquals(2, results.size());
+        assertTrue(results.stream().noneMatch(idea -> idea.getStatus() == IdeaStatus.DELETED));
+    }
+
+    private User buildUser(String username, String email) {
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword("secret123");
+        user.setEmail(email);
+        return user;
+    }
+
+    private Idea buildIdea(User user, String title, String description, IdeaStatus status, Set<Tag> tags) {
+        Idea idea = new Idea();
+        idea.setUser(user);
+        idea.setTitle(title);
+        idea.setDescription(description);
+        idea.setStatus(status);
+        idea.setTags(tags);
+        return idea;
+    }
+
+    private Tag buildTag(String name) {
+        Tag tag = new Tag();
+        tag.setName(name);
+        tag.setUsageCount(1L);
+        return tag;
+    }
+}


### PR DESCRIPTION
## Summary
- Implements complete Idea CRUD API with 6 endpoints
- Dynamic filtering via JPA Specifications (keyword, tag, userId)
- Tag auto-creation with usage count synchronization
- Batch liked status query to avoid N+1
- Soft delete with status=DELETED
- Permission enforcement (author-only update, author/admin delete)

## Closes
Closes #4

## Changes
- `IdeaController` - 6 API endpoints
- `IdeaService` - Full CRUD business logic
- `IdeaSpecifications` - Dynamic query builder
- 6 DTOs for request/response
- Repository extensions for batch queries
- SecurityConfig update for 401 on missing JWT

## Testing
- [x] Unit tests: IdeaServiceTest (14 tests)
- [x] Controller tests: IdeaControllerTest (19 tests)
- [x] Integration tests: IdeaCrudIntegrationTest (5 tests)
- [x] Coverage ≥90%
- [x] All 130+ tests pass

## Checklist
- [x] Code follows project conventions
- [x] JWT authentication required for all endpoints
- [x] Validation rules enforced (title 1-100, description 1-5000, max 9 images)
- [x] No new warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)